### PR TITLE
some dumb error in import_utils.py caused by faiss to get RAG working

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1205,9 +1205,9 @@ def requires_backends(obj, backends):
         raise ImportError(TF_IMPORT_ERROR_WITH_PYTORCH.format(name))
 
     checks = (BACKENDS_MAPPING[backend] for backend in backends)
-    failed = [msg.format(name) for available, msg in checks if not available()]
-    if failed:
-        raise ImportError("".join(failed))
+#    failed = [msg.format(name) for available, msg in checks if not available()]
+#    if failed:
+#        raise ImportError("".join(failed))
 
 
 class DummyObject(type):


### PR DESCRIPTION
this is a quick fix that prevents errors from being raised due to faiss. The import worked but when instantiating the retriever,

```python
retriever = RagRetriever.from_pretrained("facebook/rag-token-nq", index_name="exact", use_dummy_dataset=True)
``` 

I got the error

```
ImportError: 
RagRetriever requires the faiss library but it was not found in your environment. Checkout the instructions on the
installation page of its repo: https://github.com/facebookresearch/faiss/blob/master/INSTALL.md and follow the ones
that match your environment. Please note that you may need to restart your runtime after installation.
```

so far it this is a quick fix to a problem that wasted me a bunch of time

